### PR TITLE
Prevent tenhou-download-game-xml.py crash when Flash state file contains other options

### DIFF
--- a/tenhou-download-game-xml.py
+++ b/tenhou-download-game-xml.py
@@ -73,7 +73,6 @@ for sol_file in sol_files:
     slength = Struct('>H')
     stype = Struct('>B')
     vlength = Struct('>H')
-    type6length = Struct('>B')
     while o < len(data) - 1:
         l, = slength.unpack_from(data, o)
         o += 2


### PR DESCRIPTION
I needed to make this change because some of my Flash state files included variables called nobgm and nose.  These were types 6 and 1, respectively.  Unlike the type 2 entries, they don't seem to come with a length field, so the o variable ended up pointing somewhere invalid.
